### PR TITLE
Open catalog PDF from navigation

### DIFF
--- a/catalogo.html
+++ b/catalogo.html
@@ -14,7 +14,7 @@
             <ul>
                 <li><a href="index.html">Inicio</a></li> <!-- Enlace a Inicio -->
                 <li><a href="nosotros.html">Nosotros</a></li> <!-- Enlace a Nosotros -->
-                <li><a href="catalogo.html">Productos y Servicios</a></li> <!-- Enlace a Productos y Servicios -->
+                <li><a href="catalogo_2025_01.pdf" target="_blank" rel="noopener noreferrer">Catálogo</a></li> <!-- Abre el catálogo en PDF en una nueva pestaña -->
                 <li><a href="contacto.html">Contacto</a></li> <!-- Enlace a Contacto -->
             </ul>
         </nav>

--- a/contacto.html
+++ b/contacto.html
@@ -14,7 +14,7 @@
             <ul>    
                 <li><a href="index.html">Inicio</a></li> <!-- Enlace a  -->
                 <li><a href="nosotros.html">Nosotros</a></li> <!-- Redirige  -->
-                <li><a href="catalogo.html">Productos y Servicios</a></li> <!-- Redirige a -->
+                <li><a href="catalogo_2025_01.pdf" target="_blank" rel="noopener noreferrer">Catálogo</a></li> <!-- Abre el catálogo en PDF en una nueva pestaña -->
                 <li><a href="contacto.html">Contacto</a></li> <!-- Redirige a -->
             </ul>
         </nav>

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
             <ul>
                 <li><a href="index.html">Inicio</a></li> <!-- Enlace a la página de inicio -->
                 <li><a href="nosotros.html">Nosotros</a></li> <!-- Enlace a la página de nosotros -->
-                <li><a href="catalogo.html">Productos y Servicios</a></li> <!-- Enlace al catálogo de productos y servicios -->
+                <li><a href="catalogo_2025_01.pdf" target="_blank" rel="noopener noreferrer">Catálogo</a></li> <!-- Abre el catálogo en PDF en una nueva pestaña -->
                 <li><a href="contacto.html">Contacto</a></li> <!-- Enlace a la página de contacto -->
             </ul>
         </nav>

--- a/nosotros.html
+++ b/nosotros.html
@@ -14,7 +14,7 @@
             <ul>
                 <li><a href="index.html">Inicio</a></li> <!-- Enlace a inicio -->
                 <li><a href="nosotros.html">Nosotros</a></li> <!-- Enlace a nosotros -->
-                <li><a href="catalogo.html">Productos y Servicios</a></li> <!-- Enlace a productos y servicios -->
+                <li><a href="catalogo_2025_01.pdf" target="_blank" rel="noopener noreferrer">Catálogo</a></li> <!-- Abre el catálogo en PDF en una nueva pestaña -->
                 <li><a href="contacto.html">Contacto</a></li> <!-- Enlace a contacto -->
             </ul>
         </nav>
@@ -34,7 +34,7 @@
 
                     Elaboramos nuestros productos de manera artesanal en el Estado de México, cuidando cada 
                     fórmula y seleccionando ingredientes efectivos y seguros para tu hogar. 
-                    <a href = "catalogo.html">Conoce nuestros productos aquí. </a>
+                    <a href = "catalogo_2025_01.pdf" target="_blank" rel="noopener noreferrer">Conoce nuestros productos aquí. </a>
                     Nos apasiona la limpieza, pero también la honestidad y la cercanía con nuestros 
                     clientes, por eso cada galón que vendemos está pensado para ayudarte a ahorrar sin sacrificar calidad.
 


### PR DESCRIPTION
## Summary
- Link the navigation's **Catálogo** item directly to `catalogo_2025_01.pdf`, opening the document in a new browser tab for easy viewing and download.
- Update internal reference on the *Nosotros* page so the catalog link also opens the PDF in a new tab.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c197835a0c8327b2a411962add43b7