### PR TITLE
Use light teal backgrounds for body and header

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -3,14 +3,14 @@ body {
     font-family: 'Poppins', sans-serif; /* Fuente principal moderna */
     margin: 0; /* Elimina márgenes por defecto */
     padding: 0; /* Elimina relleno por defecto */
-    background: linear-gradient(to right, #ffffff, #ffffff); /* Fondo degradado */
+    background: linear-gradient(to right, #bce4e5, #bce4e5); /* Fondo degradado */
     color: #333; /* Color del texto en tono oscuro */
     text-align: center; /* Alineación del texto */
 }
 
 /* Estilos para el encabezado */
 header {
-    background-color: #ffffff; /* Color de fondo */
+    background-color: #bce4e5; /* Color de fondo */
     color: rgb(17, 28, 236); /* Color del texto */
     padding: 20px; /* Espaciado interno */
     display: flex; /* Activa flexbox */


### PR DESCRIPTION
## Summary
- replace default white gradient and header background with light teal `#bce4e5`
- verified text colors remain dark for strong contrast

## Testing
- `python - <<'PY' ...` (contrast ratio calculations)


------
https://chatgpt.com/codex/tasks/task_e_68c5098c67c08327844786caefc06093