### PR TITLE
Rotar logotipos en encabezado y sección nosotros

### DIFF
--- a/catalogo.html
+++ b/catalogo.html
@@ -9,7 +9,7 @@
 <body>
     <!-- Cabecera -->
     <header>
-        <div class="logo"><img src="logo.png" alt="Jabbon!"></div> <!-- Logo de la marca -->
+        <div class="logo"><img class="rotated-logo" src="logo.png" alt="Jabbon!"></div> <!-- Logo de la marca -->
         <nav> <!-- Menú de navegación -->
             <ul>
                 <li><a href="index.html">Inicio</a></li> <!-- Enlace a Inicio -->

--- a/contacto.html
+++ b/contacto.html
@@ -9,7 +9,7 @@
 <body>
     <!-- Cabecera principal -->
     <header>
-        <div class="logo"><img src="logo.png" alt="Jabbon!"></div>
+        <div class="logo"><img class="rotated-logo" src="logo.png" alt="Jabbon!"></div>
         <nav> <!-- Menú de navegación -->
             <ul>    
                 <li><a href="index.html">Inicio</a></li> <!-- Enlace a  -->

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
 <body>
     <!-- Cabecera principal -->
     <header>
-        <div class="logo"> <img src="logo.png" alt="Jabbon!">  </div> <!-- Logo de la marca -->
+        <div class="logo"> <img class="rotated-logo" src="logo.png" alt="Jabbon!">  </div> <!-- Logo de la marca -->
         <nav> <!-- Menú de navegación -->
             <ul>
                 <li><a href="index.html">Inicio</a></li> <!-- Enlace a la página de inicio -->

--- a/nosotros.html
+++ b/nosotros.html
@@ -9,7 +9,7 @@
 <body>
     <!-- Cabecera principal -->
     <header>
-        <div class="logo"><img src="logo.png" alt="Jabbon!"></div> <!-- Logo de la marca -->
+        <div class="logo"><img class="rotated-logo" src="logo.png" alt="Jabbon!"></div> <!-- Logo de la marca -->
         <nav> <!-- Menú de navegación -->
             <ul>
                 <li><a href="index.html">Inicio</a></li> <!-- Enlace a inicio -->
@@ -45,7 +45,7 @@
             </div>
             <!-- Bloque de imagen (opcional) -->
             <div class="about-image">
-                <img src="logo.png" alt="Jabbon!">
+                <img class="rotated-logo" src="logo.png" alt="Jabbon!">
             </div>
         </div>
     </section>

--- a/styles.css
+++ b/styles.css
@@ -36,7 +36,12 @@ header .logo img {
     margin-right: 10px;     /* Espacio entre imagen y texto */
     display: inline-block;
     vertical-align: middle;
-  /*  transform: rotate(-90deg); /* Asegura orientación correcta */
+}
+
+/* Reutilizable para imágenes de logotipo con orientación vertical */
+.rotated-logo {
+    transform: rotate(-90deg); /* Ajusta la orientación del archivo original */
+    transform-origin: center center; /* Mantiene el giro sobre el centro */
 }
 
 /* Estilos para la navegación */
@@ -291,7 +296,6 @@ h2 {
 .about-image img {
     width: 100%;
     border-radius: 5px;
-    transform: rotate(-90deg); /* Orienta el logo correctamente */
 }
 
 /* ===================== */


### PR DESCRIPTION
## Summary
- reutilicé una clase CSS para girar el logotipo a -90 grados y simplificar su estilo
- apliqué la nueva clase a los logotipos del encabezado en todas las páginas y al logotipo de la sección "Nosotros"

## Testing
- no tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c83bb442548327a8b12a7958bd3da2