### PR TITLE
Update WhatsApp contact link

### DIFF
--- a/catalogo.html
+++ b/catalogo.html
@@ -198,7 +198,7 @@
         <p><strong>Email:</strong> </p> <!-- Correo electrónico -->
     </div>
 
-    <a href="https://wa.me/+525532054736" class="whatsapp-float" target="_blank">
+    <a href="https://wa.me/525532054736" class="whatsapp-float" target="_blank">
       <img src="whats-icon.webp" alt="WhatsApp">
     </a>
 

--- a/contacto.html
+++ b/contacto.html
@@ -63,7 +63,7 @@
         <p><strong>Email:</strong> </p> <!-- Correo electrónico -->
     </div>
 
-    <a href="https://wa.me/+525532054736" class="whatsapp-float" target="_blank">
+    <a href="https://wa.me/525532054736" class="whatsapp-float" target="_blank">
       <img src="whats-icon.webp" alt="WhatsApp">
     </a>
 

--- a/index.html
+++ b/index.html
@@ -136,7 +136,7 @@
       <!-- <p>&copy; 2025 Jabbon. Todos los derechos reservados.</p>  Derechos de autor -->
 
 <!-- flotante whatsapp -->    
-    <a href="https://wa.me/+525532054736" class="whatsapp-float" target="_blank">
+    <a href="https://wa.me/525532054736" class="whatsapp-float" target="_blank">
       <img src="whats-icon.webp" alt="WhatsApp">
     </a>
 

--- a/nosotros.html
+++ b/nosotros.html
@@ -107,7 +107,7 @@
       <!-- <p>&copy; 2025 Jabbon. Todos los derechos reservados.</p>  Derechos de autor -->
     </footer>
 
-    <a href="https://wa.me/+525532054736" class="whatsapp-float" target="_blank">
+    <a href="https://wa.me/525532054736" class="whatsapp-float" target="_blank">
       <img src="whats-icon.webp" alt="WhatsApp">
     </a>
 


### PR DESCRIPTION
## Summary
- update the WhatsApp floating action button link across all pages
- ensure the link opens a chat with +52 55 3205 4736 using the proper wa.me format

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68c84c7960608327ab1910c6fb79dbce