### PR TITLE
Lighten neutral gray backgrounds

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -163,7 +163,7 @@ h2 {
     margin: 40px auto;                 /* Márgenes superior/inferior y centrado */
     padding: 20px;                     /* Espaciado interno */
     border-radius: 25px;               /* Bordes redondeados */
-    background-color: #97acc8;       /* Fondo claro */
+    background-color: #dfe6f5;       /* Fondo claro más suave */
     width: 80%;                        /* Ocupa el 80% del ancho */
     animation: fadeInUp 0.5s ease-out; /* Animación de aparición */
 }
@@ -227,7 +227,7 @@ h2 {
     display: flex;
     align-items: center;
     flex: 1 1 calc(25% - 20px);
-    background-color: #97acc8;
+    background-color: #dfe6f5;
     margin: 10px;
     padding: 20px;
     border-radius: 5px;
@@ -262,7 +262,7 @@ h2 {
 /* ===================== */
 .about {
     padding: 50px 20px;
-    background-color: #97acc8;
+    background-color: #dfe6f5;
 }
 
 .about .container {
@@ -316,7 +316,7 @@ h2 {
 
 .value-item {
     flex: 1 1 30%;
-    background-color: #97acc8;
+    background-color: #dfe6f5;
     margin: 10px;
     padding: 20px;
     border-radius: 5px;


### PR DESCRIPTION
## Summary
- soften the shared gray backgrounds used for product, service, and about sections to reduce contrast with dark text and the multicolor logo

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c85c5ea9b08327a50c17bdb2360b2a